### PR TITLE
Switch to RestClient for MQTT credentials and device queries

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -30,4 +30,4 @@ jobs:
       - run: npm ci
       - run: npm publish
         env:
-          NODE_AUTH_TOKEN: ${{secrets.npm_token}}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/ecoflow-api.js
+++ b/ecoflow-api.js
@@ -1,8 +1,11 @@
+import { RestClient } from "@ecoflow-api/rest-client";
+
 module.exports = function(RED) {
 
     const axios = require('axios');
     const http  = require('http');
 
+    
     function RemoteServerNode(n) {
         RED.nodes.createNode(this,n);
 
@@ -11,6 +14,12 @@ module.exports = function(RED) {
         let ecoflowApiServer = n.server;
         let accessKey = node.credentials.access_key;
         let secretKey = node.credentials.secret_key;
+
+        const client = new RestClient({
+            accessKey: accessKey,
+            secretKey: secretKey,
+            host: ecoflowApiServer,
+        });
 
         request = axios.create({
             baseURL: ecoflowApiServer,
@@ -84,7 +93,7 @@ module.exports = function(RED) {
             return EcoflowRequest("/iot-open/sign/device/quota", {}, 'PUT', {sn: sn, ...values });
         }
         node.queryMqttCert =  function(sn) {
-            return EcoflowRequest("/iot-open/sign/certification", {});
+            return client.getMqttCredentials();;
         }
     }
 

--- a/ecoflow-api.js
+++ b/ecoflow-api.js
@@ -81,16 +81,16 @@ module.exports = function(RED) {
         }
 
         node.queryQuotaAll = function(sn) {
-            return EcoflowRequest("/iot-open/sign/device/quota/all", { sn: sn });
+            return client.getDevicePropertiesPlain(sn);
         }
         node.queryDeviceList = function() {
-            return EcoflowRequest("/iot-open/sign/device/list", {});
+            return client.getDevicesPlain();
         }
         node.queryQuotaSelective = function(sn, types) {
             return EcoflowRequest("/iot-open/sign/device/quota", {}, 'POST', {sn: sn, params: {cmdSet: 32, id: 66, quotas: types}});
         }
         node.setQuotaSelective = function(sn, values) {
-            return EcoflowRequest("/iot-open/sign/device/quota", {}, 'PUT', {sn: sn, ...values });
+            return client.setCommandPlain({sn: sn, ...values });
         }
         node.queryMqttCert =  function(sn) {
             return client.getMqttCredentials();;

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "node": ">=12.0.0"
   },
   "dependencies": {
-    "axios": "^1.7.2"
+    "axios": "^1.7.2",
+    "@ecoflow-api/rest-client": "^1.0.3"
   },
   "devDependencies": {
     "mocha": "^10.6.0",


### PR DESCRIPTION
Refactor the code to utilize the RestClient library for obtaining MQTT credentials and querying device properties, enhancing maintainability and consistency across the codebase.